### PR TITLE
[ FIX ] Merge .add() methods

### DIFF
--- a/src/main/java/ru/astondevs/utils/collections/ObjectList.java
+++ b/src/main/java/ru/astondevs/utils/collections/ObjectList.java
@@ -20,17 +20,12 @@ public class ObjectList<T extends Comparable<T>> {
         this.size = 0;
     }
 
-    public void add(T element) {
-        ensureCapacity(size + 1);
-        elements[size++] = element;
-    }
-
     @SafeVarargs
     public final void add(T... elements) {
         for (T element : elements) {
-            add(element);
+            ensureCapacity(size + 1);
+            elements[size++] = element;
         }
-
     }
 
     public void addAll(T[] elementsToAdd) {


### PR DESCRIPTION
Методом .add() теперь можно
пользоваться как для случая
с одним аргументом, так и
с неограниченным кол-вом

Иначе возникала неопределённость,
когда вызов .add(object)
одновременно подходил и под
метод .add(T element) и под
метод .add(T... elements),
на что ругался компилятор

---
В будущем лучше вернуть
метод .add(T element)
и удалить с вараргсом,
иначе не безопасный код
получается